### PR TITLE
fix: resolve bun:sql compatibility and prom-client errors

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -12,5 +12,5 @@ export const sql = new SQL(connectionString)
 export async function query<T>(queryStr: string): Promise<T[]> {
   // Note: Using raw queries with bun:sql requires caution.
   // We'll use this as a bridge for now or update services to use sql`` directly.
-  return (await sql.query(queryStr).all()) as T[]
+  return (await sql.unsafe(queryStr)) as T[]
 }

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -14,7 +14,7 @@ export const domainExpiryGauge = new Gauge({
 export class MetricsService {
   async updateDomainMetrics() {
     try {
-      // Menggunakan query dari @y.sql
+      // Menggunakan query dari bun:sql
       const results = (await sql`
         SELECT 
             cs.CustDomain AS domain, 
@@ -32,15 +32,19 @@ export class MetricsService {
                 FROM Services 
                 WHERE ServiceGroup = 'DO'
             )
-      `.all()) as {
+      `) as {
         domain: string
         subscriber_id: string
         expiry_date: Date | string
         expiry_timestamp: number
       }[]
 
-      domainRegistry.clear()
+      domainExpiryGauge.reset()
       results.forEach((row) => {
+        if (!row.domain || row.expiry_timestamp === null) {
+          return
+        }
+
         // Memastikan format tanggal YYYY-MM-DD untuk label
         const dateObj = new Date(row.expiry_date)
         const dateString = dateObj.toISOString().split('T')[0]

--- a/src/services/sd.service.ts
+++ b/src/services/sd.service.ts
@@ -28,8 +28,8 @@ export class SDService {
           t.Status = ${'Open'} 
           AND t.TtsTypeId = 6 
           AND cst.Network LIKE ${'%/32'} 
-          AND COALESCE(c.DisplayBranchId, c.BranchId) IN ${branches}
-    `.all()) as {
+          AND FIND_IN_SET(COALESCE(c.DisplayBranchId, c.BranchId), ${branches.join(',')})
+    `) as {
       ticket_id: string
       subscriber_id: string
       subscriber_name: string


### PR DESCRIPTION
Menyelesaikan masalah pada #3 yang meliputi perbaikan query `bun:sql`, penggantian array pada klausa `IN` menggunakan `FIND_IN_SET`, serta penanganan error `null` dan _reset_ pada metrik _registry_.