### PR TITLE
Fix: Empty Response on Metrics Endpoint

### DIFF
--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -65,7 +65,7 @@ export class MetricsService {
         dependentServiceMap.set(ds.domain, String(ds.service_id))
       })
 
-      domainRegistry.clear()
+      domainExpiryGauge.reset()
       results.forEach((row) => {
         if (!row.domain || row.expiry_timestamp === null) {
           return


### PR DESCRIPTION
Replacing Registry.clear() with Gauge.reset() prevents unregistering metrics from the registry, ensuring data is correctly served on the metrics endpoint. Closes #7