### PR TITLE
Add Service Discovery Endpoint for Iforte FTTx Customers

### DIFF
--- a/src/routes/sd.routes.ts
+++ b/src/routes/sd.routes.ts
@@ -20,4 +20,20 @@ router.get('/ticket-monitoring', async (c) => {
   return c.json(targets)
 })
 
+router.get('/iforte-fttx', async (c) => {
+  const branchParam = c.req.query('branch')
+  const branchesParam = c.req.queries('branch')
+
+  let branchList: string[] | undefined
+
+  if (branchesParam && branchesParam.length > 0) {
+    branchList = branchesParam
+  } else if (branchParam) {
+    branchList = branchParam.split(',')
+  }
+
+  const targets = await sdService.getIforteFttxTargets(branchList)
+  return c.json(targets)
+})
+
 export default router

--- a/src/services/sd.service.ts
+++ b/src/services/sd.service.ts
@@ -49,6 +49,50 @@ export class SDService {
 
     return targets
   }
+
+  async getIforteFttxTargets(
+    branchIds?: string[]
+  ): Promise<PrometheusTarget[]> {
+    // Default branch jika tidak ditentukan
+    const branches =
+      branchIds && branchIds.length > 0
+        ? branchIds
+        : ['020', '027', '028', '029']
+
+    const results = (await sql`
+      SELECT 
+          cs.CustServId AS subscriber_id, 
+          cs.CustAccName AS subscriber_name, 
+          SUBSTRING_INDEX(TRIM(cst.Network), '/', 1) AS ip_address 
+      FROM CustomerServiceTechnical cst 
+      LEFT JOIN CustomerServices cs ON cs.CustServId = cst.CustServId 
+      LEFT JOIN CustomerServiceTechnicalLink cstl ON cstl.custServId = cst.CustServId 
+      LEFT JOIN noc_fiber nf ON nf.id = cstl.foVendorId 
+      LEFT JOIN fiber_vendor fv ON fv.id = nf.vendorId 
+      LEFT JOIN Customer c ON c.CustId = cs.CustId 
+      WHERE 
+          fv.name = ${'Iforte'} 
+          AND cs.CustStatus IN ('AC', 'FR') 
+          AND cst.Network LIKE ${'%/32'} 
+          AND FIND_IN_SET(COALESCE(c.DisplayBranchId, c.BranchId), ${branches.join(',')})
+    `) as {
+      subscriber_id: string
+      subscriber_name: string
+      ip_address: string
+    }[]
+
+    const targets: PrometheusTarget[] = results.map((row) => ({
+      targets: [row.ip_address],
+      labels: {
+        ip: row.ip_address,
+        host: row.subscriber_name || 'Unknown',
+        csid: String(row.subscriber_id),
+        aspect: 'iforte_fttx_monitoring',
+      },
+    }))
+
+    return targets
+  }
 }
 
 export const sdService = new SDService()


### PR DESCRIPTION
This PR adds the GET /sd/iforte-fttx endpoint to dynamically discover active FTTx customers connected via the Iforte vendor network. It supports branch filtering and outputs Prometheus-compatible HTTP SD targets. Closes #9