### PR TITLE
Update Labels for Iforte FTTx Endpoint

### DIFF
--- a/src/services/sd.service.ts
+++ b/src/services/sd.service.ts
@@ -87,7 +87,8 @@ export class SDService {
         ip: row.ip_address,
         host: row.subscriber_name || 'Unknown',
         csid: String(row.subscriber_id),
-        aspect: 'iforte_fttx_monitoring',
+        aspect: 'fttx',
+        operator: 'Iforte',
       },
     }))
 


### PR DESCRIPTION
Changes the aspect label to 'fttx' and adds an 'operator' label with the value 'Iforte'.