### PR TITLE
Add Operator Ticket SLA Metrics Endpoint (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 | Endpoint | Method | Deskripsi |
 | :--- | :--- | :--- |
 | `/metrics/domains` | `GET` | Mengekspos metrik `domain_expiry_timestamp` (Unix timestamp) dengan label pendukung seperti `domain`, `expiry` (YYYY-MM-DD), dan `csid`. |
+| `/metrics/operator-tickets` | `GET` | Mengekspos metrik `operator_ticket_created_timestamp_seconds` (Gauge) dengan label `operator`, `ticket`, `csid`, `host`, `request_number`, `ticket_number`, `category`, `status`. Fallbacks: `ticket_number="pending"`, `category="unknown"`, `status="submitted"`. |
 
 ## ⚙️ Instalasi & Setup
 

--- a/src/routes/metrics.routes.ts
+++ b/src/routes/metrics.routes.ts
@@ -1,5 +1,9 @@
 import { Hono } from 'hono'
-import { domainRegistry, operatorRegistry, metricsService } from '../services/metrics.service'
+import {
+  domainRegistry,
+  operatorRegistry,
+  metricsService,
+} from '../services/metrics.service'
 
 const router = new Hono()
 

--- a/src/routes/metrics.routes.ts
+++ b/src/routes/metrics.routes.ts
@@ -1,11 +1,17 @@
 import { Hono } from 'hono'
-import { domainRegistry, metricsService } from '../services/metrics.service'
+import { domainRegistry, operatorRegistry, metricsService } from '../services/metrics.service'
 
 const router = new Hono()
 
 router.get('/domains', async (c) => {
   await metricsService.updateDomainMetrics()
   const metrics = await domainRegistry.metrics()
+  return c.text(metrics)
+})
+
+router.get('/operator-tickets', async (c) => {
+  await metricsService.updateOperatorTicketMetrics()
+  const metrics = await operatorRegistry.metrics()
   return c.text(metrics)
 })
 

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -11,6 +11,25 @@ export const domainExpiryGauge = new Gauge({
   registers: [domainRegistry],
 })
 
+// Operator Ticket Metrics Registry (SLA monitoring for operator/vendor tickets)
+export const operatorRegistry = new Registry()
+
+export const operatorTicketGauge = new Gauge({
+  name: 'operator_ticket_created_timestamp_seconds',
+  help: 'Unix timestamp when the operator ticket was created',
+  labelNames: [
+    'operator',
+    'ticket',
+    'csid',
+    'host',
+    'request_number',
+    'ticket_number',
+    'category',
+    'status',
+  ],
+  registers: [operatorRegistry],
+})
+
 export class MetricsService {
   async updateDomainMetrics() {
     try {
@@ -91,6 +110,69 @@ export class MetricsService {
       })
     } catch (error) {
       console.error('Error updating domain metrics:', error)
+    }
+  }
+
+  // New: Update operator/vendor ticket metrics for SLA monitoring
+  async updateOperatorTicketMetrics() {
+    try {
+      const rows = (await sql`
+        SELECT 
+          fvt.insert_time,
+          UNIX_TIMESTAMP(fvt.insert_time) AS insert_timestamp,
+          cs.CustServId AS subscriber_id,
+          cs.CustAccName AS subscriber_name,
+          fvt.vendor_ticket_number AS request_number,
+          fvt.vendor_escalation_ticket_number AS ticket_number,
+          fvt.vendor_ticket_category AS category,
+          fvt.vendor_ticket_status AS status,
+          fvt.ticket_id
+        FROM FiberVendorTickets fvt
+        LEFT JOIN Tts t ON t.TtsId = fvt.ticket_id
+        LEFT JOIN CustomerServices cs ON cs.CustServId = t.CustServId
+        WHERE 
+          fvt.fiber_vendor_id = 1
+          AND t.Status NOT IN ('Call', 'Pending', 'Cancel', 'Closed')
+      `) as {
+        insert_time: Date | string | null
+        insert_timestamp: number | null
+        subscriber_id: string | null
+        subscriber_name: string | null
+        request_number: string | null
+        ticket_number: string | null
+        category: string | null
+        status: string | null
+        ticket_id: string | null
+      }[]
+
+      operatorTicketGauge.reset()
+
+      rows.forEach((row) => {
+        if (row.insert_timestamp === null || row.insert_timestamp === undefined) {
+          return
+        }
+
+        const ticketNumber = row.ticket_number ?? 'pending'
+        const category = row.category ?? 'unknown'
+        const status = row.status ?? 'submitted'
+        const host = row.subscriber_name ?? 'Unknown'
+
+        operatorTicketGauge.set(
+          {
+            operator: 'fbstar',
+            ticket: String(row.ticket_id ?? ''),
+            csid: String(row.subscriber_id ?? ''),
+            host,
+            request_number: String(row.request_number ?? ''),
+            ticket_number: ticketNumber,
+            category,
+            status,
+          },
+          Number(row.insert_timestamp)
+        )
+      })
+    } catch (error) {
+      console.error('Error updating operator ticket metrics:', error)
     }
   }
 }

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -148,7 +148,10 @@ export class MetricsService {
       operatorTicketGauge.reset()
 
       rows.forEach((row) => {
-        if (row.insert_timestamp === null || row.insert_timestamp === undefined) {
+        if (
+          row.insert_timestamp === null ||
+          row.insert_timestamp === undefined
+        ) {
           return
         }
 


### PR DESCRIPTION
Implements operator ticket metrics endpoint /metrics/operator-tickets per issue #20.\n\n- Adds operatorRegistry and operatorTicketGauge\n- Adds MetricsService.updateOperatorTicketMetrics\n- Adds route GET /metrics/operator-tickets\n\nNull label fallbacks: ticket_number="pending", category="unknown", status="submitted".\n\nCloses #20