### PR TITLE
Add Data Quality Metrics Endpoint for Missing Vendor Circuit IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@
 | :--- | :--- | :--- |
 | `/metrics/domains` | `GET` | Mengekspos metrik `domain_expiry_timestamp` (Unix timestamp) dengan label pendukung seperti `domain`, `expiry` (YYYY-MM-DD), dan `csid`. |
 | `/metrics/operator-tickets` | `GET` | Mengekspos metrik `operator_ticket_created_timestamp_seconds` (Gauge) dengan label `operator`, `ticket`, `csid`, `host`, `request_number`, `ticket_number`, `category`, `status`. Fallbacks: `ticket_number="pending"`, `category="unknown"`, `status="submitted"`. |
+| `/metrics/data-quality` | `GET` | Mengekspos metrik `data_quality_missing_circuit_id` (Gauge) untuk pelanggan aktif yang belum memiliki Vendor Circuit ID. Label: `operator="fbstar"`, `csid`, `host`, `status`. |
+
+#### Data Quality Metrics
+Endpoint `/metrics/data-quality` mengekspos metrik bertipe Gauge bernama `data_quality_missing_circuit_id`. Metrik ini menunjukkan pelanggan aktif yang terhubung melalui vendor Fbstar (vendor id = 1) tetapi memiliki nilai Vendor CID kosong.
+
+Labels:
+- operator: tetap `fbstar`
+- csid: subscriber id (CustServId)
+- host: nama pelanggan (CustAccName), fallback `Unknown`
+- status: subscription status (CustStatus), fallback `Unknown`
+
+Contoh output Prometheus:
+```
+# HELP data_quality_missing_circuit_id Pelanggan aktif yang belum memiliki Vendor Circuit ID
+# TYPE data_quality_missing_circuit_id gauge
+data_quality_missing_circuit_id{operator="fbstar",csid="105523",host="PT. Maju Bersama",status="AC"} 1
+```
 
 ## ⚙️ Instalasi & Setup
 

--- a/src/routes/metrics.routes.ts
+++ b/src/routes/metrics.routes.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import {
   domainRegistry,
   operatorRegistry,
+  dataQualityRegistry,
   metricsService,
 } from '../services/metrics.service'
 
@@ -16,6 +17,12 @@ router.get('/domains', async (c) => {
 router.get('/operator-tickets', async (c) => {
   await metricsService.updateOperatorTicketMetrics()
   const metrics = await operatorRegistry.metrics()
+  return c.text(metrics)
+})
+
+router.get('/data-quality', async (c) => {
+  await metricsService.updateDataQualityMetrics()
+  const metrics = await dataQualityRegistry.metrics()
   return c.text(metrics)
 })
 

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -32,6 +32,15 @@ export const operatorTicketGauge = new Gauge({
   registers: [operatorRegistry],
 })
 
+export const dataQualityRegistry = new Registry()
+
+export const dataQualityMissingCIDGauge = new Gauge({
+  name: 'data_quality_missing_circuit_id',
+  help: 'Pelanggan aktif yang belum memiliki Vendor Circuit ID',
+  labelNames: ['operator', 'csid', 'host', 'status'],
+  registers: [dataQualityRegistry],
+})
+
 export class MetricsService {
   async updateDomainMetrics() {
     try {
@@ -194,6 +203,61 @@ export class MetricsService {
       })
     } catch (error) {
       console.error('Error updating operator ticket metrics:', error)
+    }
+  }
+
+  async updateDataQualityMetrics() {
+    try {
+      const rows = (await sql`
+        SELECT 
+            cstl.CustServId AS subscriber_id, 
+            cs.CustAccName AS subscriber_name, 
+            cstc.value AS circuit_id, 
+            cs.CustStatus AS subscription_status 
+        FROM CustomerServiceTechnicalCustom cstc 
+        LEFT JOIN CustomerServiceTechnicalLink cstl 
+            ON cstl.id = cstc.technicalTypeId 
+        LEFT JOIN CustomerServices cs 
+            ON cs.CustServId = cstl.CustServId 
+        LEFT JOIN Customer c 
+            ON c.CustId = cs.CustId 
+        LEFT JOIN noc_fiber nf 
+            ON nf.id = cstl.foVendorId 
+        LEFT JOIN fiber_vendor fv 
+            ON nf.vendorId = fv.id 
+        WHERE 
+            cstc.technicalType = 'link' 
+            AND cstc.attribute = 'Vendor CID' 
+            AND cstl.CustServId IS NOT NULL 
+            AND cs.CustStatus NOT IN ('NA', 'BL') 
+            AND fv.id = 1 
+            AND (cstc.value = '' OR cstc.value IS NULL);
+      `) as {
+        subscriber_id: string | null
+        subscriber_name: string | null
+        circuit_id: string | null
+        subscription_status: string | null
+      }[]
+
+      dataQualityMissingCIDGauge.reset()
+
+      rows.forEach((row) => {
+        const csid = String(row.subscriber_id ?? '')
+        const host = row.subscriber_name ?? 'Unknown'
+        const status = row.subscription_status ?? 'Unknown'
+
+        dataQualityMissingCIDGauge.set(
+          {
+            operator: 'fbstar',
+            csid,
+            host,
+            status,
+          },
+          1
+        )
+      })
+    } catch (error) {
+      console.error('Error updating data quality metrics:', error)
     }
   }
 }


### PR DESCRIPTION
Implements #22: adds /metrics/data-quality endpoint exposing data_quality_missing_circuit_id gauge.